### PR TITLE
feat: Toggle Ghost Piece Functionality

### DIFF
--- a/client-ts/src/game/Game.test.ts
+++ b/client-ts/src/game/Game.test.ts
@@ -182,4 +182,12 @@ describe('Game', () => {
         expect(game.score).toBe(100);
         expect(game.lines).toBe(1);
     });
+
+    it('should have ghost piece enabled by default and toggle correctly', () => {
+        expect(game.ghostPieceEnabled).toBe(true);
+        game.toggleGhostPiece();
+        expect(game.ghostPieceEnabled).toBe(false);
+        game.toggleGhostPiece();
+        expect(game.ghostPieceEnabled).toBe(true);
+    });
 });

--- a/client-ts/src/game/Game.ts
+++ b/client-ts/src/game/Game.ts
@@ -30,6 +30,7 @@ export class Game {
     private dropInterval: number = 1000; // 1 second
 
     isPaused: boolean = false;
+    ghostPieceEnabled: boolean = true;
 
     start(): void {
         this.gameOver = false;
@@ -50,6 +51,10 @@ export class Game {
         if (!this.gameOver) {
             this.isPaused = !this.isPaused;
         }
+    }
+
+    toggleGhostPiece(): void {
+        this.ghostPieceEnabled = !this.ghostPieceEnabled;
     }
 
     update(deltaTime: number): void {

--- a/client-ts/src/game/GameUI.test.ts
+++ b/client-ts/src/game/GameUI.test.ts
@@ -72,4 +72,26 @@ describe('GameUI', () => {
         expect(menu.style.display).toBe('none');
         expect(game.isPaused).toBe(false);
     });
+
+    it('should toggle ghost piece setting when Ghost Piece option is clicked', () => {
+        ui.init();
+        const pauseBtn = root.querySelector('#pauseBtn') as HTMLButtonElement;
+
+        // Open menu
+        pauseBtn.click();
+
+        const ghostBtn = root.querySelector('#menuGhostBtn') as HTMLButtonElement;
+        expect(ghostBtn).not.toBeNull();
+        expect(ghostBtn.textContent).toBe('Ghost Piece: ON');
+
+        // Click to toggle OFF
+        ghostBtn.click();
+        expect(ghostBtn.textContent).toBe('Ghost Piece: OFF');
+        expect(game.ghostPieceEnabled).toBe(false);
+
+        // Click to toggle ON
+        ghostBtn.click();
+        expect(ghostBtn.textContent).toBe('Ghost Piece: ON');
+        expect(game.ghostPieceEnabled).toBe(true);
+    });
 });

--- a/client-ts/src/game/GameUI.ts
+++ b/client-ts/src/game/GameUI.ts
@@ -48,6 +48,11 @@ export class GameUI {
             this.updatePauseBtnText();
         });
 
+        const ghostBtn = createMenuItem('menuGhostBtn', `Ghost Piece: ${this.game.ghostPieceEnabled ? 'ON' : 'OFF'}`, () => {
+            this.game.toggleGhostPiece();
+            ghostBtn.textContent = `Ghost Piece: ${this.game.ghostPieceEnabled ? 'ON' : 'OFF'}`;
+        });
+
         const renameBtn = createMenuItem('menuRenameBtn', 'Rename (Next feature)');
         // renameBtn.disabled = true;
 
@@ -57,6 +62,7 @@ export class GameUI {
         });
 
         this.menu.appendChild(restartBtn);
+        this.menu.appendChild(ghostBtn);
         this.menu.appendChild(renameBtn);
         this.menu.appendChild(quitBtn);
 

--- a/client-ts/src/game/Renderer.ts
+++ b/client-ts/src/game/Renderer.ts
@@ -39,7 +39,7 @@ export class Renderer {
         });
 
         // Draw Ghost Piece
-        if (game.currentPiece) {
+        if (game.currentPiece && game.ghostPieceEnabled) {
             const ghostPos = game.getGhostPosition();
             game.currentPiece.shape.forEach((row, r) => {
                 row.forEach((cell, c) => {


### PR DESCRIPTION
# 📋 Summary
This PR introduces the ability to toggle the ghost piece visibility, allowing players to enable or disable the preview of where the current falling piece will land. It builds upon the existing ghost piece functionality, making it a configurable game option accessible via the UI.

# 🎯 Type
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ⚡ Performance improvement
- [ ] 🔧 Refactoring
- [ ] 📝 Documentation
- [ ] 🎨 UI/Style
- [ ] 💥 Breaking change

# 📝 Changes
- **Introduced a `ghostPieceEnabled` flag** to the game state to control the visibility of the ghost piece.
- **Implemented a `toggleGhostPiece` method** within the game logic to easily switch the ghost piece's enabled state.
- **Integrated a new menu option** into the UI, allowing players to toggle the ghost piece feature on or off during gameplay.
- **Modified the renderer** to conditionally draw the ghost piece based on the `ghostPieceEnabled` flag, ensuring it only appears when the feature is active.
- **Enhanced the existing ghost piece preview**, which was initially added for hard drop, by making its continuous display an optional setting, providing players with more control over their visual feedback.

# 📸 Screenshots
<!-- Add screenshots or recordings if applicable -->
<img width="430" height="650" alt="Screenshot 2568-12-15 at 21 05 38" src="https://github.com/user-attachments/assets/c7975b56-a003-42b8-957f-b01ca2acad91" />


# 🧪 Testing
- [x] Manual testing completed
  - Verified that the ghost piece can be toggled on and off via the new UI menu option.
  - Confirmed that the ghost piece correctly appears and disappears based on its enabled state.
  - Ensured that hard drop functionality still correctly utilizes the ghost piece preview, regardless of the toggle setting for continuous display.

# 🚀 Migration/Deployment
- [ ] Database migration required
- [ ] Environment variables updated
- [ ] Dependencies installed(Dep1, Dep2, ...)

```bash
# Migration commands if applicable
```

# 🔗 Related Issues
<!-- Link to related issues or PRs -->
- Closes #<!-- issue number -->
- Related to #<!-- issue number -->
- Fixes #<!-- issue number -->

**Breaking Changes**: No
**Migration Required**: No