### PR TITLE
feat: Implement Leaderboards Separate by Game Mode and Add Legacy Score Migration

### DIFF
--- a/client-ts/CHANGELOG.md
+++ b/client-ts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.4] - 2025-12-18
+### Fixed
+- **Leaderboard Bugs**: Separated high scores for "Solo Mode" and "Special Mode". Each mode now maintains its own independent leaderboard to ensure fair competition.
+- **Backward Compatibility**: Added migration check to preserve existing offline scores.
+
 ## [1.0.3] - 2025-12-17
 ### Added
 - **HUD Improvements**: 

--- a/client-ts/README.md
+++ b/client-ts/README.md
@@ -9,7 +9,8 @@ Old C++/Raylib client is being migrated to this **TypeScript + HTML5 Canvas** ve
 - **Game Modes:**
     - **Classic Solo Mode**: Standard Tetris gameplay.
     - **Special Mode**: Features "Cascade Gravity" and **Hold Mechanic**.
-    - **Offline Support**: Full gameplay, Auto-Save, and Local Leaderboard without internet.
+    - **Offline Support**: Full gameplay, Auto-Save without internet.
+    - **Leaderboard**: Local offline leaderboard to track top scores (separate lists for Solo and Special modes).
 - **Controls:**
     - **Keyboard:** 
         - Vectors: Arrows to move, Up to rotate.

--- a/client-ts/package.json
+++ b/client-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tetris-battle-ts",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client-ts/src/game/Game.ts
+++ b/client-ts/src/game/Game.ts
@@ -215,7 +215,7 @@ export class Game {
         // Check collision immediately
         if (!this.board.isValidPosition(this.currentPiece, this.position.x, this.position.y)) {
             this.gameOver = true;
-            this.leaderboard.addScore(this.playerName, this.score);
+            this.leaderboard.addScore(this.playerName, this.score, this.mode);
             this.currentPiece = null; // Clean up
         }
         // this.saveState(); // Removed per user request

--- a/client-ts/src/game/GameLeaderboardIntegration.test.ts
+++ b/client-ts/src/game/GameLeaderboardIntegration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Game } from './Game';
 import { Leaderboard } from './Leaderboard';
+import { GameMode } from './GameMode';
 
 describe('Game Leaderboard Integration', () => {
     let game: Game;
@@ -42,6 +43,6 @@ describe('Game Leaderboard Integration', () => {
         (game as any).spawnPiece();
 
         expect(game.gameOver).toBe(true);
-        expect(addScoreSpy).toHaveBeenCalledWith('Bob', 500);
+        expect(addScoreSpy).toHaveBeenCalledWith('Bob', 500, GameMode.OFFLINE);
     });
 });

--- a/client-ts/src/game/GameUI.ts
+++ b/client-ts/src/game/GameUI.ts
@@ -349,7 +349,7 @@ export class GameUI {
             if (nameEl) nameEl.textContent = `Player: ${this.game.playerName}`;
             if (scoreEl) scoreEl.textContent = `Score: ${this.game.score}`;
 
-            const scores = this.game.leaderboard.getTopScores();
+            const scores = this.game.leaderboard.getTopScores(this.game.mode);
             const best = scores.length > 0 ? scores[0].score : this.game.score;
             if (bestScoreEl) bestScoreEl.textContent = `Best: ${best}`;
 
@@ -407,13 +407,14 @@ export class GameUI {
     }
 
     showLeaderboard() {
-        const scores = this.game.leaderboard.getTopScores();
+        const scores = this.game.leaderboard.getTopScores(this.game.mode);
         if (scores.length === 0) {
             alert('No scores yet!');
             return;
         }
         const message = scores.map((s, i) => `${i + 1}. ${s.name} - ${s.score}`).join('\n');
-        alert(`🏆 Leaderboard 🏆\n\n${message}`);
+        const modeName = this.game.mode === GameMode.SPECIAL ? 'Special' : 'Normal';
+        alert(`🏆 Leaderboard (${modeName}) 🏆\n\n${message}`);
     }
 
     updateModeDisplay() {

--- a/client-ts/src/game/LeaderboardModes.test.ts
+++ b/client-ts/src/game/LeaderboardModes.test.ts
@@ -1,0 +1,76 @@
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Leaderboard } from './Leaderboard';
+import { GameMode } from './GameMode';
+
+describe('Leaderboard Modes', () => {
+    let leaderboard: Leaderboard;
+
+    beforeEach(() => {
+        localStorage.clear();
+        leaderboard = new Leaderboard();
+    });
+
+    it('should separate scores for different modes', () => {
+        // Add score to OFFLINE mode
+        leaderboard.addScore('Player1', 100, GameMode.OFFLINE);
+
+        // Add score to SPECIAL mode
+        leaderboard.addScore('Player2', 200, GameMode.SPECIAL);
+
+        // Check OFFLINE scores
+        const offlineScores = leaderboard.getTopScores(GameMode.OFFLINE);
+        expect(offlineScores).toHaveLength(1);
+        expect(offlineScores[0].name).toBe('Player1');
+        expect(offlineScores[0].score).toBe(100);
+
+        // Check SPECIAL scores
+        const specialScores = leaderboard.getTopScores(GameMode.SPECIAL);
+        expect(specialScores).toHaveLength(1);
+        expect(specialScores[0].name).toBe('Player2');
+        expect(specialScores[0].score).toBe(200);
+    });
+
+    it('should default to OFFLINE mode if no mode provided', () => {
+        // Call addScore without the mode argument
+        leaderboard.addScore('DefaultPlayer', 150);
+
+        const offlineScores = leaderboard.getTopScores(GameMode.OFFLINE);
+        const specialScores = leaderboard.getTopScores(GameMode.SPECIAL);
+
+        expect(offlineScores).toHaveLength(1);
+        expect(offlineScores[0].name).toBe('DefaultPlayer');
+        expect(offlineScores[0].score).toBe(150);
+
+        // Ensure it didn't leak to other modes
+        expect(specialScores).toHaveLength(0);
+    });
+
+    it('should return empty array for initialized GameMode with no scores', () => {
+        // GameMode.ONLINE has not been touched yet
+        const onlineScores = leaderboard.getTopScores(GameMode.ONLINE);
+        expect(onlineScores).toEqual([]);
+        expect(onlineScores).toBeInstanceOf(Array);
+    });
+
+    it('should handle adding score to a completely new GameMode', () => {
+        // Using GameMode.ONLINE as the "new" mode
+        leaderboard.addScore('OnlinePlayer', 300, GameMode.ONLINE);
+
+        const onlineScores = leaderboard.getTopScores(GameMode.ONLINE);
+        expect(onlineScores).toHaveLength(1);
+        expect(onlineScores[0].name).toBe('OnlinePlayer');
+        expect(onlineScores[0].score).toBe(300);
+    });
+
+    it('should handle invalid or unexpected values gracefully', () => {
+        // Test with empty name and negative score
+        // Current implementation allows it, this verifies it doesn't crash
+        leaderboard.addScore('', -50, GameMode.OFFLINE);
+
+        const scores = leaderboard.getTopScores(GameMode.OFFLINE);
+        expect(scores).toHaveLength(1);
+        expect(scores[0].name).toBe('');
+        expect(scores[0].score).toBe(-50);
+    });
+});


### PR DESCRIPTION
# 📋 Summary
This PR introduces mode-specific leaderboards, ensuring that scores achieved in "Solo Mode" (default/offline) and "Special Mode" are tracked and ranked independently.

It also includes necessary logic to handle backward compatibility, automatically migrating existing single-key offline scores to the new mode-prefixed storage key upon the first score submission or retrieval attempt.

# 🎯 Type
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ⚡ Performance improvement
- [x] 🔧 Refactoring
- [ ] 📝 Documentation
- [ ] 🎨 UI/Style
- [ ] 💥 Breaking change

# 📝 Changes
*   **Leaderboard Separation**: The `Leaderboard` class was refactored to accept a `GameMode` parameter in `addScore` and `getTopScores`.
*   **Storage Keys**: Local Storage keys are now prefixed with the game mode (`tetris_leaderboard_solo`, `tetris_leaderboard_special`, etc.) instead of a single static key.
*   **Backward Compatibility**: Added migration checks within `Leaderboard.getTopScores()` specifically for `GameMode.OFFLINE` (Solo Mode) to detect and use legacy scores stored under the old key if no mode-specific data exists yet.
*   **Game Integration**: The `Game` class now passes its current mode when adding a score upon game over.
*   **UI Updates**: The `GameUI` now correctly fetches and displays the leaderboard relevant to the active game mode, and the leaderboard alert title specifies the mode (e.g., "Leaderboard (Special)").
*   Updated documentation (README and CHANGELOG) to reflect the new feature.

# 📸 Screenshots
(N/A - Internal logic/backend change, minor UI alert change)

# 🧪 Testing
- [x] Manual testing completed (Verified solo scores don't appear in special mode, and vice versa. Verified old scores persist.)

# 🚀 Migration/Deployment
- [ ] Database migration required
- [ ] Environment variables updated
- [ ] Dependencies installed(Dep1, Dep2, ...)

```bash
# Migration commands if applicable
# N/A. Local storage migration handled automatically in Leaderboard.ts
```

# 🔗 Related Issues
<!-- Link to related issues or PRs -->
- Closes #<!-- issue number -->
- Related to #<!-- issue number -->
- https://github.com/oatrice/Tetris-Battle/issues/98
- Fixes #<!-- issue number -->

**Breaking Changes**: No
**Migration Required**: No (Handled internally via legacy score detection in `Leaderboard.ts`)