### PR TITLE
style: Update piece and effect colors for improved clarity

### DIFF
--- a/client-ts/src/game/Game.ts
+++ b/client-ts/src/game/Game.ts
@@ -179,10 +179,10 @@ export class Game {
         // Select color based on number of lines cleared
         let effectColor = '#ffffff'; // Default white
         switch (count) {
-            case 1: effectColor = '#00f0f0'; break; // Cyan (Single)
-            case 2: effectColor = '#00f000'; break; // Green (Double)
-            case 3: effectColor = '#f0a000'; break; // Orange (Triple)
-            case 4: effectColor = '#f0f000'; break; // Yellow (Tetris)
+            case 1: effectColor = '#4DD0E1'; break; // Cyan
+            case 2: effectColor = '#81C784'; break; // Green
+            case 3: effectColor = '#FFB74D'; break; // Orange
+            case 4: effectColor = '#FFF176'; break; // Yellow
         }
 
         // Add effects

--- a/client-ts/src/game/Renderer.ts
+++ b/client-ts/src/game/Renderer.ts
@@ -34,7 +34,7 @@ export class Renderer {
         game.board.grid.forEach((row, y) => {
             row.forEach((cell, x) => {
                 if (cell !== 0) {
-                    this.drawBlock(x, y, '#888'); // Gray for locked blocks
+                    this.drawBlock(x, y, '#546E7A'); // Darker Blue-Grey for locked blocks
                 }
             });
         });
@@ -153,13 +153,13 @@ export class Renderer {
 
     private getColor(type: string): string {
         const colors: Record<string, string> = {
-            I: '#00f0f0',
-            J: '#0000f0',
-            L: '#f0a000',
-            O: '#f0f000',
-            S: '#00f000',
-            T: '#a000f0',
-            Z: '#f00000',
+            I: '#4DD0E1', // Cyan (Darker Pastel)
+            J: '#7986CB', // Indigo (Darker Pastel)
+            L: '#FFB74D', // Orange (Darker Pastel)
+            O: '#FFF176', // Yellow (Darker Pastel)
+            S: '#81C784', // Green (Darker Pastel)
+            T: '#BA68C8', // Purple (Darker Pastel)
+            Z: '#E57373', // Red (Darker Pastel)
         };
         return colors[type] || '#fff';
     }


### PR DESCRIPTION
# 📋 Summary
This PR introduces a standardized and updated color palette for the game, improving visual clarity and modernizing the aesthetic.

Colors for Tetromino pieces, locked blocks, and line clear effects have been updated from basic RGB values to a consistent set of darker pastel/material design hex codes.

# 🎯 Type
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ⚡ Performance improvement
- [ ] 🔧 Refactoring
- [ ] 📝 Documentation
- [x] 🎨 UI/Style
- [ ] 💥 Breaking change

# 📝 Changes
This change focuses entirely on updating hardcoded color values in the rendering logic:

1.  **Piece Colors (`Renderer.ts`)**: The primary colors for all seven Tetromino types (I, J, L, O, S, T, Z) have been replaced with a new palette (e.g., `#4DD0E1` for Cyan/I, `#E57373` for Red/Z).
2.  **Locked Block Color (`Renderer.ts`)**: The color used to render pieces already set on the board (locked blocks) has been changed from a generic gray (`#888`) to a darker blue-grey (`#546E7A`) to provide better contrast against the active piece.
3.  **Line Clear Effects (`Game.ts`)**: The visual effect colors triggered upon clearing 1, 2, 3, or 4 lines have been updated to match the new color scheme, ensuring consistency between piece colors and effect feedback.

# 📸 Screenshots
<!-- Add screenshots or recordings if applicable -->

# 🧪 Testing
- [x] Manual testing completed
    * Verified that all pieces render using the new colors.
    * Verified that locked blocks are the correct dark grey.
    * Verified that line clear effects use the updated color feedback.

# 🚀 Migration/Deployment
- [ ] Database migration required
- [ ] Environment variables updated
- [ ] Dependencies installed(Dep1, Dep2, ...)

```bash
# Migration commands if applicable
```

# 🔗 Related Issues
<!-- Link to related issues or PRs -->
- Closes #<!-- issue number -->
- Related to #<!-- issue number -->
- https://github.com/oatrice/Tetris-Battle/issues/105
- Fixes #<!-- issue number -->

**Breaking Changes**: No
**Migration Required**: No